### PR TITLE
Add nav bar to help and test pages

### DIFF
--- a/src/main/webapp/help.html
+++ b/src/main/webapp/help.html
@@ -3,6 +3,20 @@
     <head>
         <meta charset="utf-8">
         <title>MRO Availability API Caller – Help</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+        <!-- Bootstrap / JQuery / Knockout. -->
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css"
+              integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous" />
+        <script src="https://code.jquery.com/jquery-3.5.1.min.js"
+        integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"
+                integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN"
+        crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js"
+                integrity="sha384-+sLIOodYLS7CIrQpBjl+C7nPvqq+FbNUBDunl/OZv93DB7Ln/533i8e/mZXLi/P+"
+        crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.5.0/knockout-min.js"></script>
         <style>
             body {
                 font-family: Arial, Helvetica, sans-serif;
@@ -18,6 +32,13 @@
         </style>
     </head>
     <body>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
+            <a class="navbar-brand" href="index.html">MRO Scripts</a>
+            <ul class="navbar-nav mr-auto">
+                <li class="nav-item"><a class="nav-link" href="test.html" target="_blank">Debug/Test</a></li>
+                <li class="nav-item"><a class="nav-link" href="help.html" target="_blank">Help</a></li>
+            </ul>
+        </nav>
         <h1>MRO Availability API Caller</h1>
         <p>
             This web application exposes simple endpoints for fetching product

--- a/src/main/webapp/test.html
+++ b/src/main/webapp/test.html
@@ -3,6 +3,20 @@
     <head>
         <meta charset="utf-8">
         <title>Product availability – test client</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+        <!-- Bootstrap / JQuery / Knockout. -->
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css"
+              integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous" />
+        <script src="https://code.jquery.com/jquery-3.5.1.min.js"
+        integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"
+                integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN"
+        crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js"
+                integrity="sha384-+sLIOodYLS7CIrQpBjl+C7nPvqq+FbNUBDunl/OZv93DB7Ln/533i8e/mZXLi/P+"
+        crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.5.0/knockout-min.js"></script>
         <style>
             body   { font-family: system-ui, sans-serif; max-width: 42rem; margin: 2rem auto; }
             textarea { width: 100%; height: 18rem; font-family: ui-monospace, monospace; }
@@ -10,6 +24,13 @@
         </style>
     </head>
     <body>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
+            <a class="navbar-brand" href="index.html">MRO Scripts</a>
+            <ul class="navbar-nav mr-auto">
+                <li class="nav-item"><a class="nav-link" href="test.html" target="_blank">Debug/Test</a></li>
+                <li class="nav-item"><a class="nav-link" href="help.html" target="_blank">Help</a></li>
+            </ul>
+        </nav>
         <p>How to use with curl:</p>
         <pre>
 curl -X POST \


### PR DESCRIPTION
## Summary
- replicate Bootstrap navigation bar on help.html and test.html so layout matches index
- include Bootstrap CSS/JS links in help.html and test.html for styling

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_685858c0f888832b95350f1bee3d25e1