### PR TITLE
Fix missing menu item

### DIFF
--- a/src/main/webapp/help.html
+++ b/src/main/webapp/help.html
@@ -38,6 +38,7 @@
             <ul class="navbar-nav mr-auto">
                 <li class="nav-item"><a class="nav-link" href="test.html" target="_blank">Debug/Test</a></li>
                 <li class="nav-item"><a class="nav-link" href="help.html" target="_blank">Help</a></li>
+                <li class="nav-item"><a class="nav-link" href="regal-loggedin.html" target="_blank">Regal Logged In</a></li>
             </ul>
         </nav>
         <h1>MRO Availability API Caller</h1>

--- a/src/main/webapp/test.html
+++ b/src/main/webapp/test.html
@@ -30,6 +30,7 @@
             <ul class="navbar-nav mr-auto">
                 <li class="nav-item"><a class="nav-link" href="test.html" target="_blank">Debug/Test</a></li>
                 <li class="nav-item"><a class="nav-link" href="help.html" target="_blank">Help</a></li>
+                <li class="nav-item"><a class="nav-link" href="regal-loggedin.html" target="_blank">Regal Logged In</a></li>
             </ul>
         </nav>
         <p>How to use with curl:</p>


### PR DESCRIPTION
## Summary
- add 'Regal Logged In' link to help page
- add 'Regal Logged In' link to test page

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_6858732b2a88832b97fbd815afd977ab