### PR TITLE
Add filter for implemented scripts

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -1443,6 +1443,10 @@
   }
 ]
             </textarea><br />
+            <div class="form-check mb-2">
+                <input class="form-check-input" type="checkbox" id="implementedOnly" checked>
+                <label class="form-check-label" for="implementedOnly">Check only implemented scripts</label>
+            </div>
             <button class="btn btn-secondary btn-sm" onclick="generateReport()">
                 Generate report
             </button>

--- a/src/main/webapp/js/report.js
+++ b/src/main/webapp/js/report.js
@@ -40,6 +40,20 @@
                     return;
                 }
 
+                const implementedOnly = document.getElementById("implementedOnly").checked;
+                if (implementedOnly) {
+                    try {
+                        const response = await fetch("http://mroscrape.top:4003/list-scripts");
+                        const data = await response.json();
+                        if (data && Array.isArray(data.scripts)) {
+                            const active = new Set(data.scripts.filter(s => s.isActive).map(s => s.name));
+                            listings = listings.filter(l => active.has(l.supplier));
+                        }
+                    } catch (err) {
+                        console.warn("Failed to fetch implemented scripts", err);
+                    }
+                }
+
                 /* ---------- 3. prepare UI ---------- */
                 const processingDiv = document.getElementById("processing");
                 const doneCounter = document.getElementById("done");


### PR DESCRIPTION
## Summary
- add checkbox to filter suppliers against active scripts
- fetch implemented scripts list and filter supplier data

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_686bf0e20d8c832b996f3c6c4c81ec3b