### PR TITLE
Adjust quantity badge color logic

### DIFF
--- a/src/main/webapp/js/report.js
+++ b/src/main/webapp/js/report.js
@@ -5,7 +5,7 @@
 
             function makeCell(id, result) {
                 const qtyBadge = (result.status === 'Success' && result.data && typeof result.data.total_qty_available !== 'undefined')
-                        ? `<span class="badge badge-pill badge-info ml-1">${result.data.total_qty_available}</span>`
+                        ? `<span class="badge badge-pill ${result.data.total_qty_available > 0 ? 'badge-success' : 'badge-secondary'} ml-1">${result.data.total_qty_available}</span>`
                         : '';
                 return `<a href="https://www.mrosupply.com/-/${id}" target="_blank" data-toggle="tooltip" data-placement="top" title="${safeTitle(result.data)}"><span class="${result.status === 'Success' ? 'badge badge-pill badge-success' : 'badge badge-pill badge-danger'}">${result.status}</span>${qtyBadge}</a>`;
             }

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
@@ -1,0 +1,16 @@
+package bc.mro.mrosupply_com_api_caller;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+
+public class ReportJsTest {
+    @Test
+    public void qtyBadgeUsesSecondaryWhenZero() throws Exception {
+        String js = new String(Files.readAllBytes(Paths.get("src/main/webapp/js/report.js")), StandardCharsets.UTF_8);
+        assertThat(js, containsString("? 'badge-success' : 'badge-secondary'"));
+    }
+}


### PR DESCRIPTION
## Summary
- change quantity badge color so zero available items display gray and positive counts stay green
- add a regression test to ensure color logic is present in `report.js`

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_686d0925b244832b8cd2b841087d67d3