### PR TITLE
Fix AOP status handling on report page

### DIFF
--- a/src/main/webapp/js/report.js
+++ b/src/main/webapp/js/report.js
@@ -4,7 +4,7 @@
             }
 
             function makeCell(id, result) {
-                const qtyBadge = (result.status === 'Success' && result.data && typeof result.data.total_qty_available !== 'undefined')
+                const qtyBadge = (result.data && typeof result.data.total_qty_available !== 'undefined')
                         ? `<span class="badge badge-pill ${result.data.total_qty_available > 0 ? 'badge-info' : 'badge-secondary'} ml-1">${result.data.total_qty_available}</span>`
                         : '';
                 return `<a href="https://www.mrosupply.com/-/${id}" target="_blank" data-toggle="tooltip" data-placement="top" title="${safeTitle(result.data)}"><span class="${result.status === 'Success' ? 'badge badge-pill badge-success' : 'badge badge-pill badge-danger'}">${result.status}</span>${qtyBadge}</a>`;
@@ -267,6 +267,9 @@
                         throw new Error("HTTP error " + response.status);
                     }
                     const data = await response.json();
+                    if (data && data.result && data.result.success === false) {
+                        return {status: "Fail", data};
+                    }
                     return {status: "Success", data};
                 } catch (err) {
                     console.warn("AOP request failed", err);

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
@@ -11,6 +11,14 @@ public class ReportJsTest {
     @Test
     public void qtyBadgeUsesSecondaryWhenZero() throws Exception {
         String js = new String(Files.readAllBytes(Paths.get("src/main/webapp/js/report.js")), StandardCharsets.UTF_8);
-        assertThat(js, containsString("? 'badge-success' : 'badge-secondary'"));
+        assertThat(js, containsString("? 'badge-info' : 'badge-secondary'"));
+        assertThat(js, containsString("result.data && typeof result.data.total_qty_available !== 'undefined'"));
+    }
+
+    @Test
+    public void aopFailureHandledAsFail() throws Exception {
+        String js = new String(Files.readAllBytes(Paths.get("src/main/webapp/js/report.js")), StandardCharsets.UTF_8);
+        assertThat(js, containsString("data.result.success === false"));
+        assertThat(js, containsString("return {status: \"Fail\""));
     }
 }


### PR DESCRIPTION
## Summary
- show quantity badge for any status
- mark AOP responses with `success:false` as **Fail**
- update tests for the new logic

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_686d2cd09364832b82e804ad916f54bc