### PR TITLE
Update report generation for catalog numbers

### DIFF
--- a/src/main/webapp/js/report.js
+++ b/src/main/webapp/js/report.js
@@ -74,7 +74,7 @@
                     counter++;
                     doneCounter.innerText = counter;
 
-                    const {supplier, id1, id2, id3} = listing;
+                    const {supplier, id1, id2, id3, catalog_number1, catalog_number2, catalog_number3} = listing;
                     const supplierSlug = supplier.toLowerCase().replace(/[^a-z0-9]+/g, '-');
 
                     const result1 = await checkLoggedInProduct(id1, cookiesText);
@@ -89,9 +89,9 @@
                     const result8 = await checkAdminProduct(id2, cookiesText);
                     const result9 = await checkAdminProduct(id3, cookiesText);
 
-                    const result10 = await checkAopProduct(supplierSlug, id1);
-                    const result11 = await checkAopProduct(supplierSlug, id2);
-                    const result12 = await checkAopProduct(supplierSlug, id3);
+                    const result10 = await checkAopProduct(supplierSlug, catalog_number1);
+                    const result11 = await checkAopProduct(supplierSlug, catalog_number2);
+                    const result12 = await checkAopProduct(supplierSlug, catalog_number3);
 
                     displayResult({
                         supplier,

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
@@ -21,4 +21,11 @@ public class ReportJsTest {
         assertThat(js, containsString("data.result.success === false"));
         assertThat(js, containsString("return {status: \"Fail\""));
     }
+
+    @Test
+    public void catalogNumbersUsedForAop() throws Exception {
+        String js = new String(Files.readAllBytes(Paths.get("src/main/webapp/js/report.js")), StandardCharsets.UTF_8);
+        assertThat(js, containsString("catalog_number1"));
+        assertThat(js, containsString("checkAopProduct(supplierSlug, catalog_number1)"));
+    }
 }


### PR DESCRIPTION
## Summary
- handle `catalog_number1-3` when processing supplier entries
- test that catalog numbers are used for AOP checks

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_687030410c60832b9a02f1dca3fcf373