### PR TITLE
Add JSON generation page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ output-*.xml
 /iframe-extractor/nbproject/
 /iframe-extractor-web/nbproject/
 /library-cli/nbproject/
+!src/main/resources/products-to-find-available.csv

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.12.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>javax</groupId>
             <artifactId>javaee-web-api</artifactId>
             <version>7.0</version>

--- a/src/main/java/bc/mro/mrosupply_com_api_caller/GenerateJsonResource.java
+++ b/src/main/java/bc/mro/mrosupply_com_api_caller/GenerateJsonResource.java
@@ -1,0 +1,20 @@
+package bc.mro.mrosupply_com_api_caller;
+
+import java.io.IOException;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("generate-json")
+public class GenerateJsonResource {
+
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response generate() throws IOException {
+        JsonGenerator generator = new JsonGenerator(new ApiCallerFrontEnd());
+        generator.generate();
+        return Response.ok("JSON files generated").build();
+    }
+}

--- a/src/main/java/bc/mro/mrosupply_com_api_caller/JsonGenerator.java
+++ b/src/main/java/bc/mro/mrosupply_com_api_caller/JsonGenerator.java
@@ -1,0 +1,152 @@
+package bc.mro.mrosupply_com_api_caller;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonWriter;
+
+public class JsonGenerator {
+
+    private final ApiCallerFrontEnd apiCaller;
+    private final String cookiesFile;
+    private final String csvFile;
+    private final String allJson;
+    private final String regalJson;
+
+    public JsonGenerator(ApiCallerFrontEnd apiCaller) {
+        this(apiCaller, "src/main/webapp/cookies.txt", "products-to-find-available.csv",
+                "src/main/webapp/suppliers-to-check-all.json",
+                "src/main/webapp/suppliers-to-check-regal.json");
+    }
+
+    public JsonGenerator(ApiCallerFrontEnd apiCaller, String cookiesFile, String csvFile,
+            String allJson, String regalJson) {
+        this.apiCaller = apiCaller;
+        this.cookiesFile = cookiesFile;
+        this.csvFile = csvFile;
+        this.allJson = allJson;
+        this.regalJson = regalJson;
+    }
+
+    public void generate() throws IOException {
+        Map<String, List<String>> csvData = readCsv();
+        String cookies = new String(Files.readAllBytes(Paths.get(cookiesFile)), StandardCharsets.UTF_8);
+        List<JsonObject> allSuppliers = loadExisting(Paths.get(allJson));
+        List<JsonObject> regalSuppliers = loadExisting(Paths.get(regalJson));
+
+        List<JsonObject> updatedAll = process(allSuppliers, csvData, cookies);
+        List<JsonObject> updatedRegal = process(regalSuppliers, csvData, cookies);
+
+        backupAndWrite(Paths.get(allJson), updatedAll);
+        backupAndWrite(Paths.get(regalJson), updatedRegal);
+    }
+
+    private Map<String, List<String>> readCsv() throws IOException {
+        Map<String, List<String>> map = new LinkedHashMap<>();
+        InputStream is = getClass().getClassLoader().getResourceAsStream(csvFile);
+        if (is == null) {
+            Path p = Paths.get(csvFile);
+            if (Files.exists(p)) {
+                is = Files.newInputStream(p);
+            }
+        }
+        if (is == null) return map;
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+            String header = br.readLine();
+            if (header == null) return map;
+            String line;
+            while ((line = br.readLine()) != null) {
+                String[] parts = line.split(",");
+                if (parts.length < 2) continue;
+                String supplier = parts[0].trim();
+                String product = parts[1].trim();
+                map.computeIfAbsent(supplier, k -> new ArrayList<>()).add(product);
+            }
+        }
+        return map;
+    }
+
+    private List<JsonObject> loadExisting(Path file) throws IOException {
+        if (!Files.exists(file)) {
+            return new ArrayList<>();
+        }
+        try (InputStream is = Files.newInputStream(file)) {
+            return Json.createReader(is).readArray().getValuesAs(JsonObject.class);
+        }
+    }
+
+    private List<JsonObject> process(List<JsonObject> existing, Map<String, List<String>> csvData, String cookies) {
+        List<JsonObject> out = new ArrayList<>();
+        for (JsonObject obj : existing) {
+            String supplier = obj.getString("supplier");
+            List<String> products = csvData.get(supplier);
+            List<String> selected;
+            if (products != null) {
+                selected = selectProducts(products, cookies);
+            } else {
+                selected = new ArrayList<>();
+            }
+            while (selected.size() < 3 && products != null && products.size() >= 3) {
+                int idx = products.size() - (3 - selected.size());
+                if (idx < 0) idx = 0;
+                selected.add(products.get(idx));
+            }
+            JsonObjectBuilder b = Json.createObjectBuilder();
+            b.add("supplier", supplier);
+            for (int i = 0; i < selected.size() && i < 3; i++) {
+                b.add("id" + (i + 1), Integer.parseInt(selected.get(i)));
+            }
+            if (selected.size() < 3) {
+                for (int i = selected.size(); i < 3; i++) {
+                    b.add("id" + (i + 1), obj.getInt("id" + (i + 1), 0));
+                }
+            }
+            b.add("catalog_number1", "OR834");
+            b.add("catalog_number2", "BF9484");
+            b.add("catalog_number3", "NGP895");
+            out.add(b.build());
+        }
+        return out;
+    }
+
+    private List<String> selectProducts(List<String> products, String cookies) {
+        List<String> result = new ArrayList<>();
+        for (String p : products) {
+            if (result.size() == 3) break;
+            ApiResponse response = apiCaller.call(p, cookies);
+            try {
+                JsonObject obj = Json.createReader(new java.io.StringReader(response.getBody())).readObject();
+                int qty = obj.getInt("total_qty_available", 0);
+                if (qty > 0) {
+                    result.add(p);
+                }
+            } catch (Exception e) {
+                // ignore malformed
+            }
+        }
+        return result;
+    }
+
+    private void backupAndWrite(Path file, List<JsonObject> data) throws IOException {
+        Path backup = file.resolveSibling("backup-" + file.getFileName().toString());
+        Files.move(file, backup, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        JsonArrayBuilder arr = Json.createArrayBuilder();
+        for (JsonObject o : data) arr.add(o);
+        try (JsonWriter w = Json.createWriter(Files.newOutputStream(file))) {
+            w.writeArray(arr.build());
+        }
+    }
+}

--- a/src/main/java/org/netbeans/rest/application/config/ApplicationConfig.java
+++ b/src/main/java/org/netbeans/rest/application/config/ApplicationConfig.java
@@ -23,6 +23,7 @@ public class ApplicationConfig extends Application {
         resources.add(bc.mro.mrosupply_com_api_caller.ProductAvailabilityAndPriceOnBackEndResource.class);
         resources.add(bc.mro.mrosupply_com_api_caller.ProductAvailabilityAndPriceOnFrontEndLoggedOutResource.class);
         resources.add(bc.mro.mrosupply_com_api_caller.ProductAvailabilityAndPriceOnFrontEndResource.class);
+        resources.add(bc.mro.mrosupply_com_api_caller.GenerateJsonResource.class);
         resources.add(org.glassfish.jersey.jsonb.internal.JsonBindingProvider.class);
         resources.add(org.glassfish.jersey.server.wadl.internal.WadlResource.class);
     }

--- a/src/main/resources/products-to-find-available.csv
+++ b/src/main/resources/products-to-find-available.csv
@@ -1,0 +1,9 @@
+supplier,productId
+SupplierA,101
+SupplierA,102
+SupplierA,103
+SupplierA,104
+SupplierB,201
+SupplierB,202
+SupplierB,203
+SupplierB,204

--- a/src/main/webapp/generate-json.html
+++ b/src/main/webapp/generate-json.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <link rel="icon" href="https://www.domaineasy.com/images/favicon/apple-touch-icon.png" />
+        <title>Generate JSON Files</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous" />
+        <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js" integrity="sha384-+sLIOodYLS7CIrQpBjl+C7nPvqq+FbNUBDunl/OZv93DB7Ln/533i8e/mZXLi/P+" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.5.0/knockout-min.js"></script>
+    </head>
+    <body class="container mt-3">
+        <nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
+            <a class="navbar-brand" href="index.html">MRO Scripts</a>
+            <ul class="navbar-nav mr-auto">
+                <li class="nav-item"><a class="nav-link" href="test.html" target="_blank">Debug/Test</a></li>
+                <li class="nav-item"><a class="nav-link" href="help.html" target="_blank">Help</a></li>
+                <li class="nav-item"><a class="nav-link" href="generate-json.html" target="_blank">Generate JSON</a></li>
+            </ul>
+        </nav>
+        <button id="generate" class="btn btn-primary">Generate new .json files</button>
+        <div id="status" class="mt-3"></div>
+        <script>
+            document.getElementById('generate').addEventListener('click', function() {
+                fetch('resources/generate-json', {method: 'POST'})
+                    .then(r => r.text())
+                    .then(t => document.getElementById('status').innerText = t)
+                    .catch(e => document.getElementById('status').innerText = 'Failed: ' + e);
+            });
+        </script>
+    </body>
+</html>

--- a/src/main/webapp/help.html
+++ b/src/main/webapp/help.html
@@ -38,6 +38,7 @@
             <ul class="navbar-nav mr-auto">
                 <li class="nav-item"><a class="nav-link" href="test.html" target="_blank">Debug/Test</a></li>
                 <li class="nav-item"><a class="nav-link" href="help.html" target="_blank">Help</a></li>
+                <li class="nav-item"><a class="nav-link" href="generate-json.html" target="_blank">Generate JSON</a></li>
             </ul>
         </nav>
         <h1>MRO Availability API Caller</h1>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -25,6 +25,7 @@
             <ul class="navbar-nav mr-auto">
                 <li class="nav-item"><a class="nav-link" href="test.html" target="_blank">Debug/Test</a></li>
                 <li class="nav-item"><a class="nav-link" href="help.html" target="_blank">Help</a></li>
+                <li class="nav-item"><a class="nav-link" href="generate-json.html" target="_blank">Generate JSON</a></li>
             </ul>
         </nav>
         <div id="report-generation-form">

--- a/src/main/webapp/test.html
+++ b/src/main/webapp/test.html
@@ -30,6 +30,7 @@
             <ul class="navbar-nav mr-auto">
                 <li class="nav-item"><a class="nav-link" href="test.html" target="_blank">Debug/Test</a></li>
                 <li class="nav-item"><a class="nav-link" href="help.html" target="_blank">Help</a></li>
+                <li class="nav-item"><a class="nav-link" href="generate-json.html" target="_blank">Generate JSON</a></li>
             </ul>
         </nav>
         <p>How to use with curl:</p>

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/GenerateJsonHtmlTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/GenerateJsonHtmlTest.java
@@ -1,0 +1,19 @@
+package bc.mro.mrosupply_com_api_caller;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+public class GenerateJsonHtmlTest {
+    @Test
+    public void pageContainsButtonAndNavLink() throws Exception {
+        String html = new String(Files.readAllBytes(Paths.get("src/main/webapp/generate-json.html")), StandardCharsets.UTF_8);
+        assertThat(html, containsString("Generate new .json files"));
+        assertThat(html, containsString("href=\"generate-json.html\""));
+    }
+}

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/JsonGeneratorTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/JsonGeneratorTest.java
@@ -1,0 +1,51 @@
+package bc.mro.mrosupply_com_api_caller;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+
+import org.junit.Test;
+
+public class JsonGeneratorTest {
+    @Test
+    public void generatorUsesFirstAvailableProducts() throws Exception {
+        Path dir = Files.createTempDirectory("gen");
+        Path csv = dir.resolve("products.csv");
+        Files.write(csv, ("supplier,productId\n" +
+                "ABB Motors and Mechanical Inc. - Baldor,111\n" +
+                "ABB Motors and Mechanical Inc. - Baldor,222\n" +
+                "ABB Motors and Mechanical Inc. - Baldor,333\n").getBytes(StandardCharsets.UTF_8));
+        Path cookies = dir.resolve("cookies.txt");
+        Files.write(cookies, "a\t1".getBytes(StandardCharsets.UTF_8));
+        Path all = dir.resolve("all.json");
+        Files.copy(Paths.get("src/main/webapp/suppliers-to-check-all.json"), all);
+        Path regal = dir.resolve("regal.json");
+        Files.copy(Paths.get("src/main/webapp/suppliers-to-check-regal.json"), regal);
+
+        ApiCallerFrontEnd mockCaller = mock(ApiCallerFrontEnd.class);
+        when(mockCaller.call("111", "a\t1"))
+            .thenReturn(new ApiResponse(200, "{\"total_qty_available\":0}"));
+        when(mockCaller.call("222", "a\t1"))
+            .thenReturn(new ApiResponse(200, "{\"total_qty_available\":5}"));
+        when(mockCaller.call("333", "a\t1"))
+            .thenReturn(new ApiResponse(200, "{\"total_qty_available\":0}"));
+
+        JsonGenerator gen = new JsonGenerator(mockCaller, cookies.toString(), csv.toString(), all.toString(), regal.toString());
+        gen.generate();
+
+        String content = new String(Files.readAllBytes(all), StandardCharsets.UTF_8);
+        assertThat(content, containsString("222"));
+        JsonArray arr = Json.createReader(new java.io.StringReader(content)).readArray();
+        assertEquals("222", arr.getJsonObject(0).get("id1").toString());
+        assertTrue(Files.exists(dir.resolve("backup-" + all.getFileName().toString())));
+    }
+}

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/NavigationTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/NavigationTest.java
@@ -1,0 +1,21 @@
+package bc.mro.mrosupply_com_api_caller;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+public class NavigationTest {
+    @Test
+    public void allPagesHaveGenerateLink() throws Exception {
+        String[] pages = {"src/main/webapp/index.html", "src/main/webapp/help.html", "src/main/webapp/test.html", "src/main/webapp/generate-json.html"};
+        for (String page : pages) {
+            String html = new String(Files.readAllBytes(Paths.get(page)), StandardCharsets.UTF_8);
+            assertThat(html, containsString("href=\"generate-json.html\""));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add HTML page to trigger supplier JSON regeneration
- hook new page into navbar for all pages
- implement `GenerateJsonResource` and `JsonGenerator` for CSV processing
- add Mockito for testing and new unit tests
- include CSV sample in resources

## Testing
- `mvn -q -DskipTests=false test`

------
https://chatgpt.com/codex/tasks/task_b_68703cd58648832b9fda73900a7fab4b