### PR TITLE
Add checkbox to JSON generator page

### DIFF
--- a/src/main/webapp/generate-json.html
+++ b/src/main/webapp/generate-json.html
@@ -21,6 +21,10 @@
             </ul>
         </nav>
         <textarea id="cookies" class="form-control" placeholder="Paste cookies here..." rows="3"></textarea><br />
+        <div class="form-check mb-2">
+            <input class="form-check-input" type="checkbox" id="implementedOnly" checked>
+            <label class="form-check-label" for="implementedOnly">Check only implemented scripts</label>
+        </div>
         <button id="generate" class="btn btn-primary">Generate new .json files</button>
         <div id="status" class="mt-3"></div>
         <pre><code id="result"></code></pre>

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/GenerateJsonHtmlTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/GenerateJsonHtmlTest.java
@@ -17,4 +17,11 @@ public class GenerateJsonHtmlTest {
         assertThat(html, containsString("href=\"generate-json.html\""));
         assertThat(html, containsString("<pre><code id=\"result\"></code></pre>"));
     }
+
+    @Test
+    public void implementedOnlyCheckboxPresentAndChecked() throws Exception {
+        String html = new String(Files.readAllBytes(Paths.get("src/main/webapp/generate-json.html")), StandardCharsets.UTF_8);
+        assertThat(html, containsString("id=\"implementedOnly\" checked"));
+        assertThat(html, containsString("Check only implemented scripts"));
+    }
 }


### PR DESCRIPTION
## Summary
- add the "Check only implemented scripts" checkbox to `generate-json.html`
- verify checkbox in new GenerateJsonHtmlTest test

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_6870ff224498832b998f608fd5e08a87