### PR TITLE
Add bulk supplier check page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This project provides a small Java application that can be deployed as a WAR and
   - `ApiCallerFrontEnd` – calls the public API when logged in.
   - `ApiCallerFrontEndLoggedOut` – calls the public API without session cookies.
 - Test utilities under `src/test` showcase basic calls to these APIs.
+- `bulk-supplier-check.html` web page allows checking multiple product IDs
+  against a selected supplier.
 
 ## Building
 

--- a/src/main/webapp/bulk-supplier-check.html
+++ b/src/main/webapp/bulk-supplier-check.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <link rel="icon" href="https://www.domaineasy.com/images/favicon/apple-touch-icon.png" />
+        <title>Bulk supplier check</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous" />
+        <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js" integrity="sha384-+sLIOodYLS7CIrQpBjl+C7nPvqq+FbNUBDunl/OZv93DB7Ln/533i8e/mZXLi/P+" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.5.0/knockout-min.js"></script>
+    </head>
+    <body class="container mt-3">
+        <nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
+            <a class="navbar-brand" href="index.html">MRO Scripts</a>
+            <ul class="navbar-nav mr-auto">
+                <li class="nav-item"><a class="nav-link" href="test.html">Debug/Test</a></li>
+                <li class="nav-item"><a class="nav-link" href="help.html">Help</a></li>
+                <li class="nav-item"><a class="nav-link" href="generate-json.html">Generate JSON</a></li>
+                <li class="nav-item"><a class="nav-link" href="bulk-supplier-check.html">Bulk supplier check</a></li>
+            </ul>
+        </nav>
+
+        <div class="form-group">
+            <label for="supplierSelect">Supplier</label>
+            <select id="supplierSelect" class="form-control"></select>
+        </div>
+        <div class="form-group">
+            <textarea id="bulkInput" class="form-control" placeholder="id catalog_number" rows="10"></textarea>
+        </div>
+        <button id="bulkCheck" class="btn btn-primary mb-2">Bulk check</button>
+        <button id="copyAvailable" class="btn btn-secondary mb-2">Copy available</button>
+        <div id="results" class="mt-3"></div>
+
+        <script>
+            async function loadSuppliers() {
+                const resp = await fetch('suppliers-to-check-all.json');
+                const data = await resp.json();
+                const names = [...new Set(data.map(x => x.supplier))].sort();
+                const sel = document.getElementById('supplierSelect');
+                names.forEach(n => {
+                    const o = document.createElement('option');
+                    o.value = n;
+                    o.textContent = n;
+                    sel.appendChild(o);
+                });
+            }
+
+            async function checkAopProduct(slug, catalogNumber) {
+                const url = `http://mroscrape.top:4003/scrapers/${slug}/availability?token=mro-high-secret&catalog_number=${encodeURIComponent(catalogNumber)}`;
+                try {
+                    const response = await fetch(url);
+                    if (!response.ok) return {available:false};
+                    const data = await response.json();
+                    const qty = data && data.result && data.result.qty_available;
+                    return {available: qty > 0};
+                } catch (e) {
+                    return {available:false};
+                }
+            }
+
+            document.addEventListener('DOMContentLoaded', loadSuppliers);
+
+            document.getElementById('bulkCheck').addEventListener('click', async () => {
+                const supplier = document.getElementById('supplierSelect').value;
+                const slug = supplier.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+                const lines = document.getElementById('bulkInput').value.trim().split(/\n+/);
+                const res = document.getElementById('results');
+                res.innerHTML = '';
+                window.availablePairs = [];
+                for (const line of lines) {
+                    const parts = line.trim().split(/\s+/);
+                    if (parts.length < 2) continue;
+                    const id = parts[0];
+                    const cat = parts[1];
+                    const r = await checkAopProduct(slug, cat);
+                    const status = r.available ? 'Available' : 'Not available';
+                    const div = document.createElement('div');
+                    div.textContent = id + '\t' + cat + ' - ' + status;
+                    res.appendChild(div);
+                    if (r.available) {
+                        window.availablePairs.push(id + '\t' + cat);
+                    }
+                }
+            });
+
+            document.getElementById('copyAvailable').addEventListener('click', () => {
+                if (window.availablePairs && window.availablePairs.length) {
+                    navigator.clipboard.writeText(window.availablePairs.join('\n'));
+                }
+            });
+        </script>
+    </body>
+</html>

--- a/src/main/webapp/generate-json.html
+++ b/src/main/webapp/generate-json.html
@@ -18,6 +18,7 @@
                 <li class="nav-item"><a class="nav-link" href="test.html">Debug/Test</a></li>
                 <li class="nav-item"><a class="nav-link" href="help.html">Help</a></li>
                 <li class="nav-item"><a class="nav-link" href="generate-json.html">Generate JSON</a></li>
+                <li class="nav-item"><a class="nav-link" href="bulk-supplier-check.html">Bulk supplier check</a></li>
             </ul>
         </nav>
         <textarea id="cookies" class="form-control" placeholder="Paste cookies here..." rows="3"></textarea><br />

--- a/src/main/webapp/help.html
+++ b/src/main/webapp/help.html
@@ -39,6 +39,7 @@
                 <li class="nav-item"><a class="nav-link" href="test.html">Debug/Test</a></li>
                 <li class="nav-item"><a class="nav-link" href="help.html">Help</a></li>
                 <li class="nav-item"><a class="nav-link" href="generate-json.html">Generate JSON</a></li>
+                <li class="nav-item"><a class="nav-link" href="bulk-supplier-check.html">Bulk supplier check</a></li>
             </ul>
         </nav>
         <h1>MRO Availability API Caller</h1>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -26,6 +26,7 @@
                 <li class="nav-item"><a class="nav-link" href="test.html">Debug/Test</a></li>
                 <li class="nav-item"><a class="nav-link" href="help.html">Help</a></li>
                 <li class="nav-item"><a class="nav-link" href="generate-json.html">Generate JSON</a></li>
+                <li class="nav-item"><a class="nav-link" href="bulk-supplier-check.html">Bulk supplier check</a></li>
             </ul>
         </nav>
         <div id="report-generation-form">

--- a/src/main/webapp/test.html
+++ b/src/main/webapp/test.html
@@ -31,6 +31,7 @@
                 <li class="nav-item"><a class="nav-link" href="test.html">Debug/Test</a></li>
                 <li class="nav-item"><a class="nav-link" href="help.html">Help</a></li>
                 <li class="nav-item"><a class="nav-link" href="generate-json.html">Generate JSON</a></li>
+                <li class="nav-item"><a class="nav-link" href="bulk-supplier-check.html">Bulk supplier check</a></li>
             </ul>
         </nav>
         <p>How to use with curl:</p>

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/BulkSupplierCheckHtmlTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/BulkSupplierCheckHtmlTest.java
@@ -1,0 +1,21 @@
+package bc.mro.mrosupply_com_api_caller;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+public class BulkSupplierCheckHtmlTest {
+    @Test
+    public void pageContainsControls() throws Exception {
+        String html = new String(Files.readAllBytes(Paths.get("src/main/webapp/bulk-supplier-check.html")), StandardCharsets.UTF_8);
+        assertThat(html, containsString("id=\"supplierSelect\""));
+        assertThat(html, containsString("id=\"bulkInput\""));
+        assertThat(html, containsString("Bulk check"));
+        assertThat(html, containsString("Copy available"));
+    }
+}

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/NavigationTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/NavigationTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 public class NavigationTest {
     @Test
     public void allPagesHaveGenerateLink() throws Exception {
-        String[] pages = {"src/main/webapp/index.html", "src/main/webapp/help.html", "src/main/webapp/test.html", "src/main/webapp/generate-json.html"};
+        String[] pages = {"src/main/webapp/index.html", "src/main/webapp/help.html", "src/main/webapp/test.html", "src/main/webapp/generate-json.html", "src/main/webapp/bulk-supplier-check.html"};
         for (String page : pages) {
             String html = new String(Files.readAllBytes(Paths.get(page)), StandardCharsets.UTF_8);
             assertThat(html, containsString("href=\"generate-json.html\""));
@@ -22,7 +22,7 @@ public class NavigationTest {
 
     @Test
     public void navigationLinksDoNotUseBlankTarget() throws Exception {
-        String[] pages = {"src/main/webapp/index.html", "src/main/webapp/help.html", "src/main/webapp/test.html", "src/main/webapp/generate-json.html"};
+        String[] pages = {"src/main/webapp/index.html", "src/main/webapp/help.html", "src/main/webapp/test.html", "src/main/webapp/generate-json.html", "src/main/webapp/bulk-supplier-check.html"};
         for (String page : pages) {
             String html = new String(Files.readAllBytes(Paths.get(page)), StandardCharsets.UTF_8);
             int navStart = html.indexOf("<nav");


### PR DESCRIPTION
## Summary
- add `bulk-supplier-check.html` app
- link new page from the navbar of all HTML pages
- mention the page in README
- create unit test `BulkSupplierCheckHtmlTest`
- extend `NavigationTest` with new page

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_68751c7ad844832b809254eb8d1fde08