### PR TITLE
Update availability parsing

### DIFF
--- a/src/main/webapp/bulk-supplier-check.html
+++ b/src/main/webapp/bulk-supplier-check.html
@@ -53,8 +53,18 @@
                     const response = await fetch(url);
                     if (!response.ok) return {available:false};
                     const data = await response.json();
-                    const qty = data && data.result && data.result.qty_available;
-                    return {available: qty > 0};
+                    let qty;
+                    if (data && data.result) {
+                        if (typeof data.result.qty_available !== 'undefined') {
+                            qty = data.result.qty_available;
+                        } else if (typeof data.result.total_qty_available !== 'undefined') {
+                            qty = data.result.total_qty_available;
+                        } else if (data.result.availability) {
+                            qty = Object.values(data.result.availability)
+                                    .reduce((sum, a) => sum + (a && a.qty ? a.qty : 0), 0);
+                        }
+                    }
+                    return {available: Number(qty) > 0};
                 } catch (e) {
                     return {available:false};
                 }

--- a/src/main/webapp/js/report.js
+++ b/src/main/webapp/js/report.js
@@ -282,6 +282,22 @@
                     if (data && data.result && data.result.success === false) {
                         return {status: "Fail", data};
                     }
+
+                    let total = data.total_qty_available;
+                    if (typeof total === 'undefined' && data.result) {
+                        if (typeof data.result.total_qty_available !== 'undefined') {
+                            total = data.result.total_qty_available;
+                        } else if (typeof data.result.qty_available !== 'undefined') {
+                            total = data.result.qty_available;
+                        } else if (data.result.availability) {
+                            total = Object.values(data.result.availability)
+                                    .reduce((sum, a) => sum + (a && a.qty ? a.qty : 0), 0);
+                        }
+                    }
+                    if (typeof total !== 'undefined') {
+                        data.total_qty_available = total;
+                    }
+
                     return {status: "Success", data};
                 } catch (err) {
                     console.warn("AOP request failed", err);

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
@@ -30,6 +30,13 @@ public class ReportJsTest {
     }
 
     @Test
+    public void availabilityHandledWhenCalculatingQty() throws Exception {
+        String js = new String(Files.readAllBytes(Paths.get("src/main/webapp/js/report.js")), StandardCharsets.UTF_8);
+        assertThat(js, containsString("data.result.availability"));
+        assertThat(js, containsString("data.total_qty_available = total"));
+    }
+
+    @Test
     public void overloadedStatusUsesWarningBadge() throws Exception {
         String js = new String(Files.readAllBytes(Paths.get("src/main/webapp/js/report.js")), StandardCharsets.UTF_8);
         assertThat(js, containsString("Overloaded"));


### PR DESCRIPTION
## Summary
- correctly parse qty from new scraper response in bulk check
- preserve qty for AOP cells when availability data is nested
- check for updated logic in unit tests

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_687520f6a7e4832b9af72066a7fb6df1