### PR TITLE
Fix AOP not active status

### DIFF
--- a/src/main/webapp/js/report.js
+++ b/src/main/webapp/js/report.js
@@ -275,10 +275,21 @@
 
                 try {
                     const response = await fetch(url);
+                    let data = null;
+                    try {
+                        data = await response.json();
+                    } catch (e) {
+                        data = null;
+                    }
+
+                    if (data && data.error && data.error.includes('not active')) {
+                        return {status: "Not active", data};
+                    }
+
                     if (!response.ok) {
                         throw new Error("HTTP error " + response.status);
                     }
-                    const data = await response.json();
+
                     if (data && data.result && data.result.success === false) {
                         return {status: "Fail", data};
                     }

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
@@ -42,4 +42,11 @@ public class ReportJsTest {
         assertThat(js, containsString("Overloaded"));
         assertThat(js, containsString("badge-warning"));
     }
+
+    @Test
+    public void notActiveStatusHandled() throws Exception {
+        String js = new String(Files.readAllBytes(Paths.get("src/main/webapp/js/report.js")), StandardCharsets.UTF_8);
+        assertThat(js, containsString("data.error && data.error.includes('not active')"));
+        assertThat(js, containsString("return {status: \"Not active\""));
+    }
 }


### PR DESCRIPTION
## Summary
- mark scrapers that return `error` as `Not active`
- cover the new JS logic in unit tests

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_68765ca93664832ba607a705fc6d9ef9