### PR TITLE
Add Selenium down status handling

### DIFF
--- a/src/main/webapp/js/report.js
+++ b/src/main/webapp/js/report.js
@@ -291,6 +291,9 @@
                     }
 
                     if (data && data.result && data.result.success === false) {
+                        if (data.result.error === 'Selenium Grid is not reachable') {
+                            return {status: "Selenium down", data};
+                        }
                         return {status: "Fail", data};
                     }
 

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
@@ -49,4 +49,11 @@ public class ReportJsTest {
         assertThat(js, containsString("data.error && data.error.includes('not active')"));
         assertThat(js, containsString("return {status: \"Not active\""));
     }
+
+    @Test
+    public void seleniumDownStatusHandled() throws Exception {
+        String js = new String(Files.readAllBytes(Paths.get("src/main/webapp/js/report.js")), StandardCharsets.UTF_8);
+        assertThat(js, containsString("data.result.error === 'Selenium Grid is not reachable'"));
+        assertThat(js, containsString("return {status: \"Selenium down\""));
+    }
 }


### PR DESCRIPTION
## Summary
- show `Selenium down` when scrapers report a Selenium Grid outage
- verify presence of new status in `report.js` via unit test

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_687661efbe7c832bb6c25b8baf2a8c1e