### PR TITLE
Add status for missing AOP scripts

### DIFF
--- a/src/main/webapp/js/report.js
+++ b/src/main/webapp/js/report.js
@@ -284,6 +284,9 @@
                     if (data && data.error && data.error.includes('not active')) {
                         return {status: "Not active", data};
                     }
+                    if (data && data.error && data.error.includes('No module named')) {
+                        return {status: "No script found", data};
+                    }
 
                     if (!response.ok) {
                         throw new Error("HTTP error " + response.status);

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
@@ -56,4 +56,11 @@ public class ReportJsTest {
         assertThat(js, containsString("data.result.error === 'Selenium Grid is not reachable'"));
         assertThat(js, containsString("return {status: \"Selenium down\""));
     }
+
+    @Test
+    public void noScriptFoundStatusHandled() throws Exception {
+        String js = new String(Files.readAllBytes(Paths.get("src/main/webapp/js/report.js")), StandardCharsets.UTF_8);
+        assertThat(js, containsString("data.error && data.error.includes('No module named')"));
+        assertThat(js, containsString("return {status: \"No script found\""));
+    }
 }


### PR DESCRIPTION
## Summary
- handle `No module` errors from the AOP API
- test that the new status is present in `report.js`

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_68767cbd903c832bb0ea9202c94cae94