### PR TITLE
Add legend table for report badges

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -83,6 +83,41 @@
                 </thead>
                 <tbody id="results-body"></tbody>
             </table>
+
+            <table class="table table-sm mt-3" id="legend-table">
+                <thead class="thead-light">
+                    <tr>
+                        <th scope="col">Badge</th>
+                        <th scope="col">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><span class="badge badge-pill badge-danger">Fail</span></td>
+                        <td>Not defined issue happen.</td>
+                    </tr>
+                    <tr>
+                        <td><span class="badge badge-pill badge-success">Success</span></td>
+                        <td>No errors returned.</td>
+                    </tr>
+                    <tr>
+                        <td><span class="badge badge-pill badge-warning">Overloaded</span></td>
+                        <td>Django overloaded, it refused to execute request.</td>
+                    </tr>
+                    <tr>
+                        <td><span class="badge badge-pill badge-secondary">Selenium down</span></td>
+                        <td>Selenium Grid is not available, AOP script cannot run without it.</td>
+                    </tr>
+                    <tr>
+                        <td><span class="badge badge-pill badge-secondary">No script found</span></td>
+                        <td>Script name is not found (not registered) in AOP service.</td>
+                    </tr>
+                    <tr>
+                        <td><span class="badge badge-pill badge-secondary">Not authorized</span></td>
+                        <td>Authorization failed on Django.</td>
+                    </tr>
+                </tbody>
+            </table>
         </div>
 
         <script src="js/cookies-db.js"></script>

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/IndexHtmlTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/IndexHtmlTest.java
@@ -19,4 +19,16 @@ public class IndexHtmlTest {
         assertThat(html, not(containsString("\"supplier\": \"A & P BEARINGS\"")));
         assertThat(html, not(containsString("load-regal-brands")));
     }
+
+    @Test
+    public void legendTableContainsAllBadges() throws Exception {
+        String html = new String(Files.readAllBytes(Paths.get("src/main/webapp/index.html")), StandardCharsets.UTF_8);
+        assertThat(html, containsString("id=\"legend-table\""));
+        assertThat(html, containsString("Fail"));
+        assertThat(html, containsString("Success"));
+        assertThat(html, containsString("Overloaded"));
+        assertThat(html, containsString("Selenium down"));
+        assertThat(html, containsString("No script found"));
+        assertThat(html, containsString("Not authorized"));
+    }
 }


### PR DESCRIPTION
## Summary
- show badge legend on the report page
- verify legend through unit test

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_68767e3db238832b837dce560fbd8288