### PR TITLE
Handle unauthorized frontend requests

### DIFF
--- a/src/main/webapp/js/report.js
+++ b/src/main/webapp/js/report.js
@@ -9,7 +9,7 @@
                         : '';
                 let cls = 'badge badge-pill badge-danger';
                 if (result.status === 'Success') cls = 'badge badge-pill badge-success';
-                else if (result.status === 'Overloaded') cls = 'badge badge-pill badge-warning';
+                else if (result.status === 'Overloaded' || result.status === 'Not authorized') cls = 'badge badge-pill badge-warning';
                 return `<a href="https://www.mrosupply.com/-/${id}" target="_blank" data-toggle="tooltip" data-placement="top" title="${safeTitle(result.data)}"><span class="${cls}">${result.status}</span>${qtyBadge}</a>`;
             }
 
@@ -151,7 +151,10 @@
 
                         if (response.status === 403) {
                             const data = await response.json();
-                            return {status: "Fail", data: data};
+                            if (data && data.detail && data.detail.includes('Authentication credentials')) {
+                                return {status: "Not authorized", data};
+                            }
+                            return {status: "Fail", data};
                         }
                         if (response.status === 429) {
                             return {status: "Overloaded", data: null};

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
@@ -63,4 +63,11 @@ public class ReportJsTest {
         assertThat(js, containsString("data.error && data.error.includes('No module named')"));
         assertThat(js, containsString("return {status: \"No script found\""));
     }
+
+    @Test
+    public void unauthorizedStatusHandled() throws Exception {
+        String js = new String(Files.readAllBytes(Paths.get("src/main/webapp/js/report.js")), StandardCharsets.UTF_8);
+        assertThat(js, containsString("data.detail && data.detail.includes('Authentication credentials')"));
+        assertThat(js, containsString("return {status: \"Not authorized\""));
+    }
 }


### PR DESCRIPTION
## Summary
- mark API responses with authentication errors as `Not authorized`
- warn about unauthorized calls using orange badge
- test for the new status

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_68767ef2e028832bb9faf11cda77020e