### PR TITLE
Fix unauthorized badge for logged-out API

### DIFF
--- a/src/main/webapp/js/report.js
+++ b/src/main/webapp/js/report.js
@@ -200,6 +200,9 @@
 
                         if (response.status === 403) {
                             const data = await response.json();
+                            if (data && data.detail && data.detail.includes('Authentication credentials')) {
+                                return {status: "Not authorized", data};
+                            }
                             return {status: "Fail", data: data};
                         }
                         if (response.status === 429) {

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
@@ -70,4 +70,14 @@ public class ReportJsTest {
         assertThat(js, containsString("data.detail && data.detail.includes('Authentication credentials')"));
         assertThat(js, containsString("return {status: \"Not authorized\""));
     }
+
+    @Test
+    public void unauthorizedStatusHandledForLoggedOut() throws Exception {
+        String js = new String(Files.readAllBytes(Paths.get("src/main/webapp/js/report.js")), StandardCharsets.UTF_8);
+        int start = js.indexOf("async function checkLoggedOutProduct");
+        int end = js.indexOf("async function checkAdminProduct", start);
+        String sub = js.substring(start, end);
+        assertThat(sub, containsString("data.detail && data.detail.includes('Authentication credentials')"));
+        assertThat(sub, containsString("return {status: \"Not authorized\""));
+    }
 }


### PR DESCRIPTION
## Summary
- detect authentication failures in `checkLoggedOutProduct`
- ensure new logic covered by unit tests

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_687683f9f91c832b85482291b8736894