### PR TITLE
Rename unauthorized to Hidden

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -113,6 +113,10 @@
                         <td>Script name is not found (not registered) in AOP service.</td>
                     </tr>
                     <tr>
+                        <td><span class="badge badge-pill badge-success">Hidden</span></td>
+                        <td>Availability hidden on purpose.</td>
+                    </tr>
+                    <tr>
                         <td><span class="badge badge-pill badge-warning">Not authorized</span></td>
                         <td>Authorization failed on Django.</td>
                     </tr>

--- a/src/main/webapp/js/report.js
+++ b/src/main/webapp/js/report.js
@@ -8,7 +8,7 @@
                         ? `<span class="badge badge-pill ${result.data.total_qty_available > 0 ? 'badge-info' : 'badge-secondary'} ml-1">${result.data.total_qty_available}</span>`
                         : '';
                 let cls = 'badge badge-pill badge-danger';
-                if (result.status === 'Success') cls = 'badge badge-pill badge-success';
+                if (result.status === 'Success' || result.status === 'Hidden') cls = 'badge badge-pill badge-success';
                 else if (result.status === 'Overloaded' || result.status === 'Not authorized') cls = 'badge badge-pill badge-warning';
                 return `<a href="https://www.mrosupply.com/-/${id}" target="_blank" data-toggle="tooltip" data-placement="top" title="${safeTitle(result.data)}"><span class="${cls}">${result.status}</span>${qtyBadge}</a>`;
             }
@@ -201,7 +201,7 @@
                         if (response.status === 403) {
                             const data = await response.json();
                             if (data && data.detail && data.detail.includes('Authentication credentials')) {
-                                return {status: "Not authorized", data};
+                                return {status: "Hidden", data};
                             }
                             return {status: "Fail", data: data};
                         }

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/IndexHtmlTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/IndexHtmlTest.java
@@ -29,6 +29,7 @@ public class IndexHtmlTest {
         assertThat(html, containsString("Overloaded"));
         assertThat(html, containsString("Selenium down"));
         assertThat(html, containsString("No script found"));
+        assertThat(html, containsString("Hidden"));
         assertThat(html, containsString("Not authorized"));
     }
 }

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
@@ -44,6 +44,13 @@ public class ReportJsTest {
     }
 
     @Test
+    public void hiddenStatusUsesSuccessBadge() throws Exception {
+        String js = new String(Files.readAllBytes(Paths.get("src/main/webapp/js/report.js")), StandardCharsets.UTF_8);
+        assertThat(js, containsString("Hidden"));
+        assertThat(js, containsString("badge-success"));
+    }
+
+    @Test
     public void notActiveStatusHandled() throws Exception {
         String js = new String(Files.readAllBytes(Paths.get("src/main/webapp/js/report.js")), StandardCharsets.UTF_8);
         assertThat(js, containsString("data.error && data.error.includes('not active')"));
@@ -78,6 +85,6 @@ public class ReportJsTest {
         int end = js.indexOf("async function checkAdminProduct", start);
         String sub = js.substring(start, end);
         assertThat(sub, containsString("data.detail && data.detail.includes('Authentication credentials')"));
-        assertThat(sub, containsString("return {status: \"Not authorized\""));
+        assertThat(sub, containsString("return {status: \"Hidden\""));
     }
 }


### PR DESCRIPTION
## Summary
- rename report status to *Hidden* for logged-out checks
- show *Hidden* badge in index legend table
- update tests for new status

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_6876fc5e90dc832bbd663dd72e8b826a