### PR TITLE
Add progress bar to report page

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -92,6 +92,10 @@
             <div class="d-none" id="processing" style="margin-bottom: 5px">
                 Processing scripts <span id="done">0</span> of <span id="length">0</span>
             </div>
+            <div class="progress mb-2 d-none" id="progress-container">
+                <div id="progress-bar" class="progress-bar" role="progressbar"
+                     style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+            </div>
 
             <table class="table d-none table-striped table-hover table-sm" id="results">
                 <thead class="thead-dark">

--- a/src/main/webapp/js/report.js
+++ b/src/main/webapp/js/report.js
@@ -61,6 +61,8 @@
                 const processingDiv = document.getElementById("processing");
                 const doneCounter = document.getElementById("done");
                 const lengthCounter = document.getElementById("length");
+                const progressBar = document.getElementById("progress-bar");
+                const progressContainer = document.getElementById("progress-container");
                 const resultsTable = document.getElementById("results");
                 const resultsBody = document.getElementById("results-body");
 
@@ -69,6 +71,9 @@
                 lengthCounter.innerText = listings.length;
                 resultsTable.classList.add("d-none");   // hidden until we have rows
                 processingDiv.classList.remove("d-none");
+                progressBar.style.width = "0%";
+                progressBar.setAttribute("aria-valuenow", "0");
+                progressContainer.classList.remove("d-none");
 
                 /* ---------- 4. run checks with limited concurrency ---------- */
                 let counter = 0;
@@ -76,6 +81,9 @@
                 async function processListing(listing) {
                     counter++;
                     doneCounter.innerText = counter;
+                    const percent = Math.round((counter / listings.length) * 100);
+                    progressBar.style.width = percent + "%";
+                    progressBar.setAttribute("aria-valuenow", percent.toString());
 
                     const {supplier, script, id1, id2, id3, catalog_number1, catalog_number2, catalog_number3} = listing;
 
@@ -128,6 +136,7 @@
                 /* ---------- 5. finish ---------- */
                 $("#report-generation-form").addClass("d-none");
                 processingDiv.classList.add("d-none");
+                progressContainer.classList.add("d-none");
             }
 
             async function checkLoggedInProduct(productId, cookiesText) {
@@ -397,6 +406,8 @@ async function generateRegalReport() {
     const processingDiv = document.getElementById("processing");
     const doneCounter = document.getElementById("done");
     const lengthCounter = document.getElementById("length");
+    const progressBar = document.getElementById("progress-bar");
+    const progressContainer = document.getElementById("progress-container");
     const resultsTable = document.getElementById("results");
     const resultsBody = document.getElementById("results-body");
 
@@ -405,12 +416,18 @@ async function generateRegalReport() {
     lengthCounter.innerText = listings.length;
     resultsTable.classList.add("d-none");
     processingDiv.classList.remove("d-none");
+    progressBar.style.width = "0%";
+    progressBar.setAttribute("aria-valuenow", "0");
+    progressContainer.classList.remove("d-none");
 
     let counter = 0;
 
     async function processRegalListing(listing) {
         counter++;
         doneCounter.innerText = counter;
+        const percent = Math.round((counter / listings.length) * 100);
+        progressBar.style.width = percent + "%";
+        progressBar.setAttribute("aria-valuenow", percent.toString());
 
         const { supplier, products } = listing;
         const results = [];
@@ -432,6 +449,7 @@ async function generateRegalReport() {
     }
 
     processingDiv.classList.add("d-none");
+    progressContainer.classList.add("d-none");
 }
 
 function displayLoggedInResult({ supplier, products, results }) {

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/IndexHtmlTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/IndexHtmlTest.java
@@ -38,4 +38,11 @@ public class IndexHtmlTest {
         String html = new String(Files.readAllBytes(Paths.get("src/main/webapp/index.html")), StandardCharsets.UTF_8);
         assertThat(html, containsString("Please read following descriptions to understand meaning of different statuses on the report."));
     }
+
+    @Test
+    public void progressBarPresent() throws Exception {
+        String html = new String(Files.readAllBytes(Paths.get("src/main/webapp/index.html")), StandardCharsets.UTF_8);
+        assertThat(html, containsString("id=\"progress-container\""));
+        assertThat(html, containsString("id=\"progress-bar\""));
+    }
 }

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
@@ -87,4 +87,11 @@ public class ReportJsTest {
         assertThat(sub, containsString("data.detail && data.detail.includes('Authentication credentials')"));
         assertThat(sub, containsString("return {status: \"Hidden\""));
     }
+
+    @Test
+    public void progressBarUpdatedDuringProcessing() throws Exception {
+        String js = new String(Files.readAllBytes(Paths.get("src/main/webapp/js/report.js")), StandardCharsets.UTF_8);
+        assertThat(js, containsString("progressBar.style.width"));
+        assertThat(js, containsString("progressContainer.classList.remove"));
+    }
 }


### PR DESCRIPTION
## Summary
- show progress bar while generating reports
- update JavaScript to control the bar
- cover new markup and behavior with tests

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_687702c9c094832b80d94b0f8c18123e