### PR TITLE
Implement backoff for overloaded API

### DIFF
--- a/src/main/webapp/js/report.js
+++ b/src/main/webapp/js/report.js
@@ -139,8 +139,8 @@
                 });
 
                 let attempts = 0;
-                const maxAttempts = 5;
-
+                const maxAttempts = 3;
+                
                 while (attempts < maxAttempts) {
                     try {
                         const response = await fetch(url, {
@@ -157,7 +157,12 @@
                             return {status: "Fail", data};
                         }
                         if (response.status === 429) {
-                            return {status: "Overloaded", data: null};
+                            attempts++;
+                            if (attempts >= maxAttempts) {
+                                return {status: "Overloaded", data: null};
+                            }
+                            await new Promise((resolve) => setTimeout(resolve, 5000 * attempts));
+                            continue;
                         }
 
                         if (!response.ok) {
@@ -173,7 +178,9 @@
                     }
 
                     attempts++;
-                    await new Promise((resolve) => setTimeout(resolve, 2000));
+                    if (attempts < maxAttempts) {
+                        await new Promise((resolve) => setTimeout(resolve, 2000));
+                    }
                 }
 
                 return {status: "Unsuccessful", data: null};
@@ -188,7 +195,7 @@
                 });
 
                 let attempts = 0;
-                const maxAttempts = 5;
+                const maxAttempts = 3;
 
                 while (attempts < maxAttempts) {
                     try {
@@ -206,7 +213,12 @@
                             return {status: "Fail", data: data};
                         }
                         if (response.status === 429) {
-                            return {status: "Overloaded", data: null};
+                            attempts++;
+                            if (attempts >= maxAttempts) {
+                                return {status: "Overloaded", data: null};
+                            }
+                            await new Promise((resolve) => setTimeout(resolve, 5000 * attempts));
+                            continue;
                         }
 
                         if (!response.ok) {
@@ -223,7 +235,9 @@
                     }
 
                     attempts++;
-                    await new Promise((resolve) => setTimeout(resolve, 2000));
+                    if (attempts < maxAttempts) {
+                        await new Promise((resolve) => setTimeout(resolve, 2000));
+                    }
                 }
 
                 return {status: "Unsuccessful", data: null};
@@ -238,7 +252,7 @@
                 });
 
                 let attempts = 0;
-                const maxAttempts = 5;
+                const maxAttempts = 3;
 
                 while (attempts < maxAttempts) {
                     try {
@@ -253,7 +267,12 @@
                             return {status: "Fail", data: data};
                         }
                         if (response.status === 429) {
-                            return {status: "Overloaded", data: null};
+                            attempts++;
+                            if (attempts >= maxAttempts) {
+                                return {status: "Overloaded", data: null};
+                            }
+                            await new Promise((resolve) => setTimeout(resolve, 5000 * attempts));
+                            continue;
                         }
 
                         if (!response.ok) {
@@ -269,7 +288,9 @@
                     }
 
                     attempts++;
-                    await new Promise((resolve) => setTimeout(resolve, 2000));
+                    if (attempts < maxAttempts) {
+                        await new Promise((resolve) => setTimeout(resolve, 2000));
+                    }
                 }
 
                 return {status: "Unsuccessful", data: null};

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
@@ -87,4 +87,11 @@ public class ReportJsTest {
         assertThat(sub, containsString("data.detail && data.detail.includes('Authentication credentials')"));
         assertThat(sub, containsString("return {status: \"Hidden\""));
     }
+
+    @Test
+    public void overloadedRetriesUseIncreasingDelay() throws Exception {
+        String js = new String(Files.readAllBytes(Paths.get("src/main/webapp/js/report.js")), StandardCharsets.UTF_8);
+        assertThat(js, containsString("const maxAttempts = 3"));
+        assertThat(js, containsString("setTimeout(resolve, 5000 * attempts)"));
+    }
 }


### PR DESCRIPTION
## Summary
- retry product checks only 3 times
- wait longer between retries when the API responds with `429`
- update tests for new delay logic

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_687703ed3cc4832bbf0c06c05f0058de