### PR TITLE
Add responsible column to legend

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -55,36 +55,44 @@
                     <tr>
                         <th scope="col">Badge</th>
                         <th scope="col">Description</th>
+                        <th scope="col">Responsible to Fix</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
                         <td><span class="badge badge-pill badge-danger">Fail</span></td>
                         <td>Not defined issue happen.</td>
+                        <td>Dima</td>
                     </tr>
                     <tr>
                         <td><span class="badge badge-pill badge-success">Success</span></td>
                         <td>No errors returned.</td>
+                        <td></td>
                     </tr>
                     <tr>
                         <td><span class="badge badge-pill badge-warning">Overloaded</span></td>
                         <td>Django overloaded, it refused to execute request.</td>
+                        <td>Krya</td>
                     </tr>
                     <tr>
                         <td><span class="badge badge-pill badge-danger">Selenium down</span></td>
                         <td>Selenium Grid is not available, AOP script cannot run without it.</td>
+                        <td>Krya</td>
                     </tr>
                     <tr>
                         <td><span class="badge badge-pill badge-danger">No script found</span></td>
                         <td>Script name is not found (not registered) in AOP service.</td>
+                        <td>Dima</td>
                     </tr>
                     <tr>
                         <td><span class="badge badge-pill badge-success">Hidden</span></td>
                         <td>Availability hidden on purpose.</td>
+                        <td></td>
                     </tr>
                     <tr>
                         <td><span class="badge badge-pill badge-warning">Not authorized</span></td>
                         <td>Authorization failed on Django.</td>
+                        <td>Order Processor Manager</td>
                     </tr>
                 </tbody>
             </table>

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/IndexHtmlTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/IndexHtmlTest.java
@@ -31,6 +31,10 @@ public class IndexHtmlTest {
         assertThat(html, containsString("No script found"));
         assertThat(html, containsString("Hidden"));
         assertThat(html, containsString("Not authorized"));
+        assertThat(html, containsString("Responsible to Fix"));
+        assertThat(html, containsString("Krya"));
+        assertThat(html, containsString("Dima"));
+        assertThat(html, containsString("Order Processor Manager"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- show a new "Responsible to Fix" column on the index page legend
- display who fixes each problem status
- update unit test to check for the new column and values

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_687f95868b90832b9f527fbfc91a2f41