### PR TITLE
Rename Unsuccessful status to Failed

### DIFF
--- a/src/main/webapp/js/report.js
+++ b/src/main/webapp/js/report.js
@@ -176,7 +176,7 @@
                     await new Promise((resolve) => setTimeout(resolve, 2000));
                 }
 
-                return {status: "Unsuccessful", data: null};
+                return {status: "Failed", data: null};
             }
 
             async function checkLoggedOutProduct(productId, cookiesText) {
@@ -226,7 +226,7 @@
                     await new Promise((resolve) => setTimeout(resolve, 2000));
                 }
 
-                return {status: "Unsuccessful", data: null};
+                return {status: "Failed", data: null};
             }
 
             async function checkAdminProduct(productId, cookiesText) {
@@ -272,7 +272,7 @@
                     await new Promise((resolve) => setTimeout(resolve, 2000));
                 }
 
-                return {status: "Unsuccessful", data: null};
+                return {status: "Failed", data: null};
             }
 
             async function checkAopProduct(script, catalogNumber) {
@@ -323,7 +323,7 @@
                     return {status: "Success", data};
                 } catch (err) {
                     console.warn("AOP request failed", err);
-                    return {status: "Unsuccessful", data: null};
+                    return {status: "Failed", data: null};
                 }
             }
 

--- a/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
+++ b/src/test/java/bc/mro/mrosupply_com_api_caller/ReportJsTest.java
@@ -87,4 +87,10 @@ public class ReportJsTest {
         assertThat(sub, containsString("data.detail && data.detail.includes('Authentication credentials')"));
         assertThat(sub, containsString("return {status: \"Hidden\""));
     }
+
+    @Test
+    public void unsuccessfulStatusRenamedToFailed() throws Exception {
+        String js = new String(Files.readAllBytes(Paths.get("src/main/webapp/js/report.js")), StandardCharsets.UTF_8);
+        assertThat(js, containsString("return {status: \"Failed\""));
+    }
 }


### PR DESCRIPTION
## Summary
- rename `Unsuccessful` status to `Failed` in report.js
- test for new status string

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_687f95d01334832b8221dc419bb05ce8